### PR TITLE
added link to RapidAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,3 +221,4 @@ Shopify tests cannot be run.
 Running Shopify tests will delete all connected store info.
 Set environment variable SHOPIFY_ALLOW_TESTS=TRUE to allow tests to be run.
 ```
+You can also test the API on [RapidAPI](https://rapidapi.com/package/Shopify/functions?utm_source=ShopifyGitHub&utm_medium=button).


### PR DESCRIPTION
I've added a link in your README to Shopify's functions page in RapidAPI. I've done this for a few Shopify SDKs to help those who are reading the READMEs, understand and test the API before use.