### PR TITLE
Updating composer instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Features include:
 ## Setup/Installation
 Uses [guzzlehttp/guzzle](https://packagist.org/packages/guzzlehttp/guzzle).
 You can include this library by running:  
-`composer require donutdan4114/shopify`
+`composer require donutdan4114/shopify@dev`
 
 ## Private & Public Apps
 You can use this library for private or public app creation. Using private apps is easier because their is no `access_token` required.


### PR DESCRIPTION
While there is no stable release tagged, we need to define @dev as the way to install the lib via composer.