### PR TITLE
Allow API feature to be passed into request

### DIFF
--- a/src/Shopify/Client.php
+++ b/src/Shopify/Client.php
@@ -36,6 +36,7 @@ abstract class Client {
     'page_info',
     'limit',
     'fields',
+    '_apiFeatures'
   ];
 
   /**


### PR DESCRIPTION
Currently, Shopify pagination does not return this parameter back in the cursor-based link, Shopify does allow you to pass this parameter into the function but gets dropped unless it exists in this Array. 

Updated array to allow this value to be passed in 